### PR TITLE
[cncf/cnf-testsuite#1812] Remove spurious logs when looking for process

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: k8s_kernel_introspection
-version: 1.0.0
+version: 1.0.1
 
 authors:
   - William Harris <wharris@upscalews.com>

--- a/src/kernel_introspection/k8s.cr
+++ b/src/kernel_introspection/k8s.cr
@@ -218,7 +218,7 @@ module KernelIntrospection
               status = ClusterTools.exec_by_node(cat_cmdline_cmd, node)
               Log.for("find_matching_processes").debug(&.emit(
                 cat_cmdline_cmd: cat_cmdline_cmd,
-                process: process[:output],
+                process: "#{process[:output]}",
                 status: "#{status}"
               ))
               if process[:output] =~ /#{process_name}/

--- a/src/kernel_introspection/k8s.cr
+++ b/src/kernel_introspection/k8s.cr
@@ -179,7 +179,7 @@ module KernelIntrospection
                 "process status and cmdline",
                 pid: pid,
                 cmdline: process[:output],
-                status: status,
+                status: "#{status}",
               ))
               if process[:output] =~ /#{process_name}/
                 ret = {node: node, pod: pod, container_status: container_status, status: status[:output], pid: pid.to_s, cmdline: process[:output]}
@@ -219,7 +219,7 @@ module KernelIntrospection
               Log.for("find_matching_processes").debug(&.emit(
                 cat_cmdline_cmd: cat_cmdline_cmd,
                 process: process[:output],
-                status: status
+                status: "#{status}"
               ))
               if process[:output] =~ /#{process_name}/
                 result = {node: node, pod: pod, container_status: container_status, status: status[:output], pid: pid.to_s, cmdline: process[:output]}


### PR DESCRIPTION
## Issues: cncf/cnf-testsuite#1812

## Description
* This PR removes spurious log messages when `LOG_LEVEL=info`.
* Also moves certain log lines to use `Log::Emitter` to output values associated with log statements.
* Bumps version to 1.0.1

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
